### PR TITLE
Newly received messages auto scrolls into view.

### DIFF
--- a/src/components/Brightbar.js
+++ b/src/components/Brightbar.js
@@ -239,11 +239,6 @@ const ConversationEntry = ({ room, messages, activeRoomID, nickname }) => {
                         ? "brightbar-conversations-entry active-conversation-entry"
                         : "brightbar-conversations-entry"
                 }
-                style={{
-                    boxShadow: currentlyActive
-                        ? "#303841 0px 0px 5px 1px inset"
-                        : ""
-                }}
             >
                 <div className="brightbar-conversations-entry-wrapper">
                     <Icon

--- a/src/components/Brightbar.js
+++ b/src/components/Brightbar.js
@@ -123,8 +123,7 @@ class Brightbar extends Component {
                                     >
                                         <ConversationSearch
                                             toggle={
-                                                this.state
-                                                    .toggleNewConversationModal
+                                                this.toggleNewConversationModal
                                             }
                                             onChange={this.onFilterChange}
                                             clearFilter={this.clearFilter}
@@ -167,7 +166,7 @@ class Brightbar extends Component {
                                                     this.state.newRoomInfo.note
                                                 }
                                                 close={
-                                                    this.state
+                                                    this
                                                         .toggleNewConversationModal
                                                 }
                                                 generate={generateRoomID}

--- a/src/components/Message.js
+++ b/src/components/Message.js
@@ -3,11 +3,11 @@ import moment from "moment";
 import UserAvatar from "./UserAvatar";
 import Linkify from "linkifyjs/react";
 
-const Message = ({ me, timestamp, message, from, darkMode }) => {
+const Message = ({ me, timestamp, message, from, darkMode, attachRef }) => {
     const yourMessages = me === from;
 
     return (
-        <div className="message-entry">
+        <div className="message-entry" ref={ref => attachRef(ref)}>
             <div
                 style={{ flexDirection: yourMessages ? "row-reverse" : "row" }}
             >
@@ -24,8 +24,10 @@ const Message = ({ me, timestamp, message, from, darkMode }) => {
                         }`}
                         style={{
                             background: yourMessages
-                            ? darkMode ? "rgba(153, 168, 180, 0.3)" : "rgba(54, 62, 71, 0.08)"
-                            : "rgba(85, 167, 212, 0.3)",
+                                ? darkMode
+                                    ? "rgba(153, 168, 180, 0.3)"
+                                    : "rgba(54, 62, 71, 0.08)"
+                                : "rgba(85, 167, 212, 0.3)",
                             color: darkMode ? "white" : "rgba(54, 62, 71, 0.7)"
                         }}
                     >

--- a/src/components/pages/Conversation.js
+++ b/src/components/pages/Conversation.js
@@ -70,7 +70,7 @@ class Conversation extends Component {
         ) {
             changeActiveRoom(match.params.roomid || "r-general");
         }
-        this.scrollToBottom();
+        // this.scrollToBottom();
     }
 
     scrollToBottom = () => {
@@ -119,7 +119,7 @@ class Conversation extends Component {
                 }));
             }
         }
-        this.scrollToBottom();
+        // this.scrollToBottom();
     };
 
     onKeyVisibilityHandle = e => {
@@ -171,11 +171,9 @@ class Conversation extends Component {
 
     onJoinModalSubmit = e => {
         e.preventDefault();
-
         const { newRoomInfo } = this.state;
         const { addNewRoom } = this.context;
 
-        console.log(newRoomInfo);
         if (
             newRoomInfo.note &&
             newRoomInfo.key &&
@@ -208,6 +206,10 @@ class Conversation extends Component {
         }
     };
 
+    changed = () => {
+        console.log("Something changed!");
+    };
+
     render() {
         let otherUser = "Anonymous";
         return (
@@ -221,7 +223,8 @@ class Conversation extends Component {
                     setNickname,
                     setKey,
                     veil,
-                    darkMode
+                    darkMode,
+                    attachRefToNewMessage
                 }) => {
                     let theRoom = rooms.filter(
                         room => room.rid === activeRoomID
@@ -317,6 +320,7 @@ class Conversation extends Component {
                                     darkMode ? "darkmode" : ""
                                 }`}
                                 id="conversation-window"
+                                onChange={this.changed}
                             >
                                 {messages
                                     .filter(
@@ -337,6 +341,7 @@ class Conversation extends Component {
                                                 timestamp={messageEntry.date}
                                                 message={messageEntry.message}
                                                 darkMode={darkMode}
+                                                attachRef={attachRefToNewMessage}
                                             />
                                         );
                                     })}
@@ -408,19 +413,8 @@ const SpeakBar = ({ _onChange, _onSpeak, message, darkMode }) => {
                 type="text"
                 placeholder="Type your message here .."
                 value={message}
+                autoFocus
             />
-            <ul>
-                <li>
-                    <a href="/">
-                        <Icon icon="fas fa-paperclip" />
-                    </a>
-                </li>
-                <li>
-                    <a href="/">
-                        <Icon icon="fas fa-file-image" />
-                    </a>
-                </li>
-            </ul>
         </div>
     );
 };

--- a/src/contexts/ConversationProvider.js
+++ b/src/contexts/ConversationProvider.js
@@ -11,19 +11,23 @@ const veil = io.connect(BACKEND_URL + "/veil");
 const ConversationContext = React.createContext();
 
 export class ConversationProvider extends Component {
-    state = {
-        rooms: [],
-        message: "", // input default value can't be null so..
-        messages: [],
-        modals: {
-            conversationSettingsModalDisplayed: false,
-            newConversationModalDisplayed: false
-        },
-        nickname: generateNickName(),
-        generatedRoomID: generateRoomID(),
-        activeRoomID: null,
-        darkMode: false
-    };
+    constructor(props) {
+        super(props);
+        this.state = {
+            rooms: [],
+            message: "", // input default value can't be null so..
+            messages: [],
+            modals: {
+                conversationSettingsModalDisplayed: false,
+                newConversationModalDisplayed: false
+            },
+            nickname: generateNickName(),
+            generatedRoomID: generateRoomID(),
+            activeRoomID: null,
+            darkMode: false
+        };
+        this.scrollToRef = this.scrollToMyRef.bind(this);
+    }
 
     /**
      * TODO: Fetch & load all saved rooms from localStorage, if exists.
@@ -90,6 +94,29 @@ export class ConversationProvider extends Component {
 
     onMessageReceived = messageEntry => {
         this.addNewMessage(messageEntry);
+        this.scrollToMyRef();
+    };
+
+    /**
+     * * Auto scroll to view.
+     * @memberof ConversationProvider
+     */
+    scrollToMyRef = () => {
+        if (this.scrollToRef) {
+            this.scrollToRef.scrollIntoView({
+                behavior: "smooth",
+                block: "end",
+                inline: "end"
+            });
+        }
+    };
+
+    /**
+     * * Receives and updates our message component refs.
+     * @memberof ConversationProvider
+     */
+    attachRefToNewMessage = msgElementRef => {
+        this.scrollToRef = msgElementRef;
     };
 
     /**
@@ -157,6 +184,7 @@ export class ConversationProvider extends Component {
                 );
             }
         }
+        this.scrollToMyRef();
     };
 
     scrollToBottom = node => {
@@ -351,7 +379,8 @@ export class ConversationProvider extends Component {
                     leaveRoom: this.onRoomLeave,
                     addNewRoom: this.addNewRoom,
                     darkMode: this.state.darkMode,
-                    toggleModes: this.toggleModes
+                    toggleModes: this.toggleModes,
+                    attachRefToNewMessage: this.attachRefToNewMessage
                 }}
             >
                 {children}


### PR DESCRIPTION
Considering all messages are emitted from the server, all messages are `received`. 

I used the React's [`createRef()`](https://reactjs.org/docs/refs-and-the-dom.html#creating-refs) in order to scroll onto new messages. Old `ref` is replaced by the newest `ref` therefore it should be fine.

Signed-off-by: Prashant Shrestha <intern0t@users.noreply.github.com>